### PR TITLE
Fixes für Patches, Bessere Fehlerbehandlung

### DIFF
--- a/openwrt-patches/luci-remove-freifunk-firewall.patch
+++ b/openwrt-patches/luci-remove-freifunk-firewall.patch
@@ -1,5 +1,5 @@
---- feeds/luci/modules/luci-mod-freifunk/Makefile.old 2015-06-07 10:41:37.522529443 +0200
-+++ feeds/luci/modules/luci-mod-freifunk/Makefile 2015-06-07 10:41:50.522495712 +0200
+--- a/feeds/luci/modules/luci-mod-freifunk/Makefile.old 2015-06-07 10:41:37.522529443 +0200
++++ b/feeds/luci/modules/luci-mod-freifunk/Makefile 2015-06-07 10:41:50.522495712 +0200
 @@ -7,7 +7,7 @@
  include $(TOPDIR)/rules.mk
  

--- a/openwrt-patches/openwrt-remove-ppp-firewall-from-deps.patch
+++ b/openwrt-patches/openwrt-remove-ppp-firewall-from-deps.patch
@@ -1,5 +1,5 @@
---- include/target.mk	2014-10-06 20:31:26.281611390 +0200
-+++ include/target.mk.orig	2014-10-06 20:30:57.365187737 +0200
+--- a/include/target.mk	2014-10-06 20:31:26.281611390 +0200
++++ b/include/target.mk.orig	2014-10-06 20:30:57.365187737 +0200
 @@ -14,7 +14,7 @@
  # Default packages - the really basic set
  DEFAULT_PACKAGES:=base-files libc libgcc busybox dropbear mtd uci opkg netifd fstools

--- a/openwrt-patches/openwrt-remove-wpad-mini-from-deps.patch
+++ b/openwrt-patches/openwrt-remove-wpad-mini-from-deps.patch
@@ -1,5 +1,5 @@
---- target/linux/ar71xx/Makefile.orig	2014-10-04 15:34:23.477881868 +0200
-+++ target/linux/ar71xx/Makefile	2014-10-06 20:29:41.112830889 +0200
+--- a/target/linux/ar71xx/Makefile.orig	2014-10-04 15:34:23.477881868 +0200
++++ b/target/linux/ar71xx/Makefile	2014-10-06 20:29:41.112830889 +0200
 @@ -19,6 +19,6 @@
  
  DEFAULT_PACKAGES += \

--- a/openwrt-patches/uml-gcc5.patch
+++ b/openwrt-patches/uml-gcc5.patch
@@ -27,7 +27,7 @@ index 0000000..ed8e476
 ++++ b/arch/um/include/shared/init.h
 +@@ -54,7 +54,7 @@ typedef void (*exitcall_t)(void);
 + #endif
-+ 
++
 + #else
 +-#if __GNUC__ == 4
 ++#if __GNUC__ >= 4
@@ -36,4 +36,3 @@ index 0000000..ed8e476
 + #endif
 -- 
 2.5.0
-


### PR DESCRIPTION
Der gcc-Patch wurde nicht applied... jetzt wird einfach git apply <patch> aufgerufen, damit klappt es. 

Patches kann man jetzt einfach mit: http://wiki.openwrt.org/doc/devel/patches erstellen und mit 
git-format-patch (http://git-scm.com/docs/git-format-patch) in eine Datei packen, die auch wieder angewandt werden kann. 

Random Stackoverflow Info:

> git apply also handles file adds, deletes, and renames if they're described in the git diff format, which patch won't do. Finally, git apply is an "apply all or abort all" model where either everything is applied or nothing is, whereas patch can partially apply patch files, leaving your working directory in a weird state.
