### PR TITLE
added CONFIG_PACKAGE_kmod-ath10k=y for Archer C7

### DIFF
--- a/openwrt-config/config_HARDWARE.ArcherC7.txt
+++ b/openwrt-config/config_HARDWARE.ArcherC7.txt
@@ -1,3 +1,4 @@
 CONFIG_TARGET_ar71xx_generic_Default is not set
 CONFIG_TARGET_ar71xx_generic_ARCHERC7=y
 CONFIG_DEFAULT_kmod-ath10k=y
+CONFIG_PACKAGE_kmod-ath10k=y


### PR DESCRIPTION
build_release.sh builds no package for kmod_ath10k driver because of missing "CONFIG_PACKAGE_kmod-ath10k=y" in openWRT
