### PR TITLE
ffweimar_standard missing in config_meta.ffweimar-4MB.txt

### DIFF
--- a/openwrt-config/config_meta.ffweimar-4MB.txt
+++ b/openwrt-config/config_meta.ffweimar-4MB.txt
@@ -1,1 +1,1 @@
-patch:luci-remove-freifunk-firewall.patch ffweimar_luci_standard hostapd vtunnoZlibnoSSL i18n_german nohttps owm shrink tc busybox busybox_swap
+ffweimar_standard patch:luci-remove-freifunk-firewall.patch ffweimar_luci_standard hostapd vtunnoZlibnoSSL i18n_german nohttps owm shrink tc busybox busybox_swap

--- a/openwrt-config/config_meta.ffweimar-ArcherC7+trunk.txt
+++ b/openwrt-config/config_meta.ffweimar-ArcherC7+trunk.txt
@@ -1,0 +1,1 @@
+meta.ffweimar-4MBtrunk HARDWARE.ArcherC7


### PR DESCRIPTION
Readme.md announces profile "ffweimar_standard" as part of meta.ffweimar-4MB, but it is missing; so this pull adds it
